### PR TITLE
feat: centralize configuration handling

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,18 @@
+import dotenv from 'dotenv';
+import { CanvasConfig } from './types.js';
+
+dotenv.config();
+
+const apiToken = process.env.CANVAS_API_TOKEN;
+const baseUrl = process.env.CANVAS_BASE_URL || 'https://fhict.instructure.com';
+
+if (!apiToken) {
+  throw new Error('CANVAS_API_TOKEN environment variable is required');
+}
+
+const config: CanvasConfig = {
+  apiToken,
+  baseUrl,
+};
+
+export default config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,11 @@ import {
   GetPromptRequestSchema,
   GetPromptResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import axios, { AxiosInstance } from 'axios';
-import { CanvasConfig, Course, Rubric } from './types.js';
-import { StudentTools } from './studentTools.js';
-import { z } from 'zod';
-import config from './config.js';
+import axios, { AxiosInstance } from "axios";
+import { CanvasConfig, Course, Rubric } from "./types.js";
+import { StudentTools } from "./studentTools.js";
+import { z } from "zod";
+import config from "./config.js";
 
 // Helper function for delay
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   ListToolsRequestSchema,
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
-  GetPromptResultSchema, // Corrected import: Use GetPromptResultSchema
+  GetPromptResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import axios, { AxiosInstance } from 'axios';
 import { CanvasConfig, Course, Rubric } from './types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -12,6 +11,7 @@ import axios, { AxiosInstance } from 'axios';
 import { CanvasConfig, Course, Rubric } from './types.js';
 import { StudentTools } from './studentTools.js';
 import { z } from 'zod';
+import config from './config.js';
 
 // Helper function for delay
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -1043,18 +1043,6 @@ Please present this information in a clear, concise format that helps me quickly
       throw error;
     }
   }
-}
-
-// Read configuration from environment variables
-const config: CanvasConfig = {
-  apiToken: process.env.CANVAS_API_TOKEN || "",
-  baseUrl: process.env.CANVAS_BASE_URL || "https://fhict.instructure.com",
-};
-
-// Validate configuration
-if (!config.apiToken) {
-  console.error("Error: CANVAS_API_TOKEN environment variable is required");
-  process.exit(1);
 }
 
 // Start the server

--- a/src/test-client.ts
+++ b/src/test-client.ts
@@ -1,9 +1,9 @@
-import 'dotenv/config';
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { spawn } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import config from './config.js';
 
 // Get directory of the current file
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -28,7 +28,7 @@ class CanvasTestClient {
     // Start server process
     const serverPath = path.join(__dirname, 'index.js');
     this.serverProcess = spawn('node', [serverPath], {
-      env: process.env,
+      env: { ...process.env, CANVAS_API_TOKEN: config.apiToken, CANVAS_BASE_URL: config.baseUrl },
       stdio: ['pipe', 'pipe', 'inherit'] // redirect stdout to pipe, stderr to console
     });
     


### PR DESCRIPTION
## Summary
- add config module to load env vars with defaults and required checks
- use shared config in server and test client instead of local dotenv calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ddc416f6c83308933fcb0de355261