### PR TITLE
test: add coverage for student tools

### DIFF
--- a/__tests__/studentTools.test.ts
+++ b/__tests__/studentTools.test.ts
@@ -28,3 +28,60 @@ describe('StudentTools.getMyTodoItems', () => {
     });
   });
 });
+
+describe('StudentTools.getUpcomingAssignments', () => {
+  it('formats upcoming assignments from multiple courses', async () => {
+    const tools = new StudentTools('https://example.com', 'token');
+    const mockGet = jest.fn()
+      .mockResolvedValueOnce({ data: [
+        { id: 1, name: 'Course A' },
+        { id: 2, name: 'Course B' }
+      ] })
+      .mockResolvedValueOnce({ data: [
+        {
+          id: 101,
+          name: 'Assignment 1',
+          due_at: '2023-01-02T00:00:00Z',
+          points_possible: 10,
+          submission: { submitted_at: null, score: null },
+          html_url: 'http://example.com/assign/101'
+        }
+      ] })
+      .mockResolvedValueOnce({ data: [] });
+    (tools as any).axiosInstance = { get: mockGet };
+
+    const result = await tools.getUpcomingAssignments();
+    expect(mockGet).toHaveBeenCalledTimes(3);
+    expect(result.content[0].text).toContain('Upcoming Assignments');
+    expect(result.content[0].text).toContain('Assignment: Assignment 1');
+    expect(result.content[0].text).toContain('Course: Course A');
+  });
+});
+
+describe('StudentTools.getCourseGrade', () => {
+  it('formats course grade information', async () => {
+    const tools = new StudentTools('https://example.com', 'token');
+    const mockGet = jest.fn()
+      .mockResolvedValueOnce({ data: { id: 42, name: 'Biology' } })
+      .mockResolvedValueOnce({ data: [
+        {
+          type: 'student',
+          current_grade: '92%',
+          current_score: 92,
+          final_grade: 'A-',
+          final_score: 90
+        }
+      ] });
+    (tools as any).axiosInstance = {
+      get: mockGet,
+      defaults: { baseURL: 'https://example.com' }
+    };
+
+    const result = await tools.getCourseGrade({ courseId: '42' });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(result.content[0].text).toContain('Grade Information for Biology');
+    expect(result.content[0].text).toContain('Current Grade: 92%');
+    expect(result.content[0].text).toContain('Final Grade: A-');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add e2e-style tests for upcoming assignments
- cover course grade formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688df257a7948330a7ff1c3f141ba702