### PR TITLE
refactor: centralize delay and pagination helpers

### DIFF
--- a/src/canvasServer.ts
+++ b/src/canvasServer.ts
@@ -13,9 +13,7 @@ import { CanvasConfig, Course, Rubric } from './types.js';
 import { StudentTools } from './studentTools.js';
 import { z } from 'zod';
 import { logger } from './logger.js';
-
-// Helper function for delay
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+import { delay } from './utils.js';
 
 // Handles integration with Canvas LMS through Model Context Protocol
 export class CanvasServer {
@@ -1045,31 +1043,6 @@ Please present this information in a clear, concise format that helps me quickly
   }
 
   // Helper method to fetch all pages
-  private async fetchAllPages(url: string, config: any): Promise<any[]> {
-    const results: any[] = [];
-    let page = 1;
-    let hasMore = true;
-
-    while (hasMore) {
-      const response = await this.axiosInstance.get(url, {
-        ...config,
-        params: {
-          ...config.params,
-          page: page,
-        },
-      });
-
-      const pageData = response.data;
-      results.push(...pageData);
-
-      const perPage = config?.params?.per_page || 10;
-      hasMore = pageData.length === perPage;
-      page += 1;
-    }
-
-    return results;
-  }
-
   // Starts the server using stdio transport
   public async start() {
     const transport = new StdioServerTransport();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,62 @@
+import { AxiosInstance, AxiosResponse } from 'axios';
+import { logger } from './logger.js';
+
+/**
+ * Pause execution for a specified number of milliseconds.
+ */
+export const delay = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Fetch all pages of a paginated Canvas API endpoint using the Link header.
+ */
+export async function fetchAllPages<T>(
+  axiosInstance: AxiosInstance,
+  initialUrl: string,
+  config?: any
+): Promise<T[]> {
+  let results: T[] = [];
+  let url: string | null = initialUrl;
+  const requestConfig = { ...config };
+
+  logger.debug(`Fetching all pages starting from: ${url}`);
+
+  while (url) {
+    try {
+      const response: AxiosResponse<T[]> = await axiosInstance.get<T[]>(
+        url,
+        requestConfig
+      );
+      const responseData = Array.isArray(response.data)
+        ? response.data
+        : [response.data];
+      results = results.concat(responseData);
+
+      const linkHeader: string | undefined = response.headers['link'];
+      url = null;
+      if (linkHeader) {
+        const links: string[] = linkHeader.split(',');
+        const nextLink: string | undefined = links.find((link: string) =>
+          link.includes('rel="next"')
+        );
+        if (nextLink) {
+          const match: RegExpMatchArray | null = nextLink.match(/<(.*?)>/);
+          if (match && match[1]) {
+            url = match[1];
+            logger.debug(`Found next page link: ${url}`);
+            if (url) {
+              await delay(100);
+            }
+          }
+        }
+      }
+    } catch (error: any) {
+      const apiError = error.response?.data?.errors?.[0]?.message || error.message;
+      throw new Error(`Failed during pagination at ${url}: ${apiError}`);
+    }
+  }
+
+  logger.debug(`Finished fetching all pages. Total items: ${results.length}`);
+  return results;
+}
+


### PR DESCRIPTION
## Summary
- create shared `delay` and `fetchAllPages` utilities
- reuse these helpers in `StudentTools` and `CanvasServer`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688df95103cc8330b6a975763a8541ec